### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/object-dot.js
+++ b/lib/object-dot.js
@@ -10,6 +10,7 @@ function set ({ object, path, value, overwrite = true, separator = '.' }) {
     let [currentProperty, ...remainingProperties] = properties
     if (object[currentProperty] === undefined) object[currentProperty] = {}
     else if (overwrite && typeof object[currentProperty] !== 'object') object[currentProperty] = {}
+    else if (isPrototypePolluted(currentProperty)) return
     set({ object: object[currentProperty], path: remainingProperties, value, overwrite, separator })
   }
   return object
@@ -45,6 +46,10 @@ function extend () {
   Object.prototype.set = set
   Object.prototype.exists = exists
   /* eslint-enable */
+}
+
+function isPrototypePolluted (key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 module.exports = { set, get, exists, extend }


### PR DESCRIPTION
### :bar_chart: Metadata *

`object-dot` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-dot

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var objectDot = require("object-dot")
var obj = {}
console.log("Before : " + {}.polluted);
objectDot.set(obj, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i object-dot # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![object-dot-fix](https://user-images.githubusercontent.com/43996156/102889119-0f696480-4480-11eb-8c96-fc88e16c704c.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
